### PR TITLE
[POC] Fallback locale validation rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
                 "Spatie\\NovaTranslatable\\NovaTranslatableServiceProvider"
             ]
         }
-    }
+    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,13 @@
     "config": {
         "sort-packages": true
     },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Spatie\\NovaTranslatable\\NovaTranslatableServiceProvider"
+            ]
+        }
+    }
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/src/NovaTranslatableServiceProvider.php
+++ b/src/NovaTranslatableServiceProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Spatie\NovaTranslatable;
+
+use Laravel\Nova\Fields\Field;
+use Illuminate\Validation\Rule;
+use Illuminate\Support\ServiceProvider;
+
+class NovaTranslatableServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        Field::macro('fallbackLocaleRules', function ($rules) {
+            $this->fallbackLocaleRules = ($rules instanceof Rule || is_string($rules)) ? func_get_args() : $rules;
+
+            return $this;
+        });
+
+        Field::macro('creationFallbackLocaleRules', function ($rules) {
+            $this->creationFallbackLocaleRules = ($rules instanceof Rule || is_string($rules)) ? func_get_args() : $rules;
+
+            return $this;
+        });
+
+        Field::macro('updateFallbackLocaleRules', function ($rules) {
+            $this->updateFallbackLocaleRules = ($rules instanceof Rule || is_string($rules)) ? func_get_args() : $rules;
+
+            return $this;
+        });
+    }
+}

--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -117,6 +117,20 @@ class Translatable extends MergeValue
                 $translatedField->attribute = 'translations_'.$originalAttribute.'_'.$locale;
                 $translatedField->panel = $this->panel;
 
+                if ($locale === config('translatable.fallback_locale')) {
+                    $translatedField->rules = array_merge(
+                        $translatedField->fallbackLocaleRules ?? [], $translatedField->rules
+                    );
+
+                    $translatedField->creationRules = array_merge(
+                        $translatedField->creationFallbackLocaleRules ?? [], $translatedField->creationRules
+                    );
+
+                    $translatedField->updateRules = array_merge(
+                        $translatedField->updateFallbackLocaleRules ?? [], $translatedField->updateRules
+                    );
+                }
+
                 return $model->translations[$originalAttribute][$locale] ?? '';
             });
 


### PR DESCRIPTION
I would like to be able to add additional validation rules for the fallback locale only. The general validation rules remain unaffected.

Example: I want to add 'required' only to fallback locale field.

This PR is a proof of concept. I am open for further ideas to help me solve the problem.