### PR TITLE
Remove Nova version dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": ">=7.2.0",
-        "laravel/nova": "^2.0",
+        "laravel/nova": "*",
         "spatie/laravel-translatable": "^4.0"
     },
     "require-dev": {


### PR DESCRIPTION
Hello,

I am using nova as a local path repository, and it doesn't recognize the version of nova as 2.0.0, and seeing it as dev,

Which causes the conflict:

  Problem 1
    - Installation request for spatie/nova-translatable ^2.0 -> satisfiable by spatie/nova-translatable[2.0.0].
    - spatie/nova-translatable 2.0.0 requires laravel/nova ^2.0 -> no matching package found.
