### PR TITLE
Allow sorting by a translatable field

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,23 @@ Translatable::make([
 
 Using the code about above the name for the `title` field will be "My title ['en']".
 
+### Sorting by translatable fields
+
+Because the translations are stored as a JSON object it can't be used for sorting by default. In the translatable fields are stored as json fields a sort locale can be specified allowing sorting by that language.
+
+```php
+Translatable::make([
+    Text::make('My title', 'title')->sortable(),
+    Trix::make('text'),
+])->sortLocale('en'),
+``` 
+
+Or can be set globally:
+
+```php
+Translatable::defaultSortLocale(config('translatable.fallback_locale'));
+``` 
+
 ## On customizing the UI
 
 You might wonder why we didn't render the translatable fields in tabs, panels or with magical unicorns displayed next to them. The truth is that everybody wants translations to be displayed a bit different. That's why we opted to keep them very simple for now.

--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -77,7 +77,9 @@ class Translatable extends MergeValue
     {
         $this->locales = $locales;
 
-        $this->createTranslatableFields();
+        if (! $this->onIndexPage()) {
+            $this->createTranslatableFields();
+        }
 
         return $this;
     }
@@ -86,7 +88,9 @@ class Translatable extends MergeValue
     {
         $this->sortLocale = $locale;
 
-        $this->createTranslatableFields();
+        if ($this->onIndexPage()) {
+            $this->createTranslatableFields();
+        }
 
         return $this;
     }
@@ -100,7 +104,9 @@ class Translatable extends MergeValue
     {
         $this->displayLocalizedNameUsingCallback = $displayLocalizedNameUsingCallback;
 
-        $this->createTranslatableFields();
+        if (! $this->onIndexPage()) {
+            $this->createTranslatableFields();
+        }
 
         return $this;
     }

--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -132,7 +132,7 @@ class Translatable extends MergeValue
 
     protected function createIndexField(Field $field): Field
     {
-        if(! $field->sortable){
+        if (! $field->sortable) {
             return $field;
         }
 


### PR DESCRIPTION
Currently sorting by a translatable field is not possible since it contains JSON data, appending sortable to a field will make it look like it's sortable but wont change the order.

This pull request allows setting a locale for sorting and therefore enabling sorting the field in that language. This is achieved by modifying the `sortableUriKey` parameter to include the language.

If no sort locale or default sort locale is defined the sortable attribute will be removed from the field as it does nothing. After some thought this might not be the same on all database engines also text based translatable fields can be ordered. Because in this case the sorting is done by the JSON string I currently do not see the benefit of this but if required I will remove this feature.

Of course I'm open to any suggestions.