### PR TITLE
Add `translatedFieldsByLocale` property

### DIFF
--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -97,7 +97,10 @@ class Translatable extends MergeValue
         collect($this->locales)
             ->crossJoin($this->originalFields)
             ->eachSpread(function (string $locale, Field $field) {
-                $this->data[] = $this->createTranslatedField($field, $locale);
+                $translatedField = $this->createTranslatedField($field, $locale);
+
+                $this->data[] = $translatedField;
+                $this->translatedFieldsByLocale[$locale][] = $translatedField;
             });
     }
 


### PR DESCRIPTION
Trying to build a custom UI around translatable fields proved to be quite the challenge for me and my team. We want to have tabs, but it's near impossible to sort the `data` property of the `Translatable` class by locale. So in this PR, I've added a `translatedFieldsByLocale` property to simplify this process and offer more flexibility in terms of other UI solutions.

Here's an example of how we've implemented this solution with tabs in a custom mail template create view:

```php
use Eminiarts\Tabs\Tabs;
use Eminiarts\Tabs\TabsOnEdit;
use NumaxLab\NovaCKEditor5Classic\CKEditor5Classic;
use Spatie\NovaTranslatable\Translatable;

class MailTemplate extends Resource
{
    use TabsOnEdit;

    ...
    public function fields(Request $request)
    {

        $translatedFields = Translatable::make($this->translatableFields());

        return [

            new Panel('', [

                ID::make()->sortable(),

                Select::make('mail_type')
                    ->options([])
                    ->exceptOnForms(),

                Text::make('name')
                    ->sortable()
                    ->rules('required', 'max:255'),

                Code::make('recipients')->json(),
                Code::make('cc')->json(),
                Code::make('bcc')->json(),

                Select::make('design')->options([]),
            ]),

            new Tabs('', $translatedFields->translatedFieldsByLocale)
        ];
    }

    protected function translatableFields() {

        return [
            Text::make('sender_name'),
            Text::make('sender_email'),
            Text::make('subject'),
            CKEditor5Classic::make('body'),
            Text::make('attachments'),
        ];
    }
}
```

The result looks something like this:

![Screenshot 2020-03-17 at 18 27 27](https://user-images.githubusercontent.com/10728938/76884164-892f4a80-687d-11ea-9993-9ff5e2718892.png)
