### PR TITLE
Remove Nova version dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": ">=7.2.0",
-        "laravel/nova": "^3.0",
+        "laravel/nova": "*",
         "spatie/laravel-translatable": "^4.0"
     },
     "require-dev": {


### PR DESCRIPTION
(Similar to previously merged PR : https://github.com/spatie/nova-translatable/pull/24)

Hello,

I am using nova as a local path repository, and it doesn't recognize the version of nova as 3.x

`Installation request for spatie/nova-translatable ^3.0 -> satisfiable by spatie/nova-translatable[3.0.0, 3.0.1, 3.0.2]`