### PR TITLE
only setTranslation for real attribute Fields

### DIFF
--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -125,7 +125,8 @@ class Translatable extends MergeValue
             });
 
         $translatedField->fillUsing(function ($request, $model, $attribute, $requestAttribute) use ($locale, $originalAttribute) {
-            $model->setTranslation($originalAttribute, $locale, $request->get($requestAttribute));
+            if ($originalAttribute)
+                $model->setTranslation($originalAttribute, $locale, $request->get($requestAttribute));
         });
 
         return $translatedField;


### PR DESCRIPTION
this would allow use of Heading fields in Translatable

```php
Translatable::make([
    Text::make('title'),
    Heading::make('Ante maecenas ligula faucibus taciti mauris lectus'),
    Text::make('description'),
    [...]
```