### PR TITLE
change translated field attribute

### DIFF
--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -110,7 +110,7 @@ class Translatable extends MergeValue
 
         $originalAttribute = $translatedField->attribute;
 
-        $translatedField->attribute = 'translations';
+        $translatedField->attribute = 'translations_'.$originalAttribute.'_'.$locale;
 
         $translatedField->name = (count($this->locales) > 1)
             ? ($this->displayLocalizedNameUsingCallback)($translatedField, $locale)
@@ -118,7 +118,6 @@ class Translatable extends MergeValue
 
         $translatedField
             ->resolveUsing(function ($value, Model $model) use ($translatedField, $locale, $originalAttribute) {
-                $translatedField->attribute = 'translations_'.$originalAttribute.'_'.$locale;
                 $translatedField->panel = $this->panel;
 
                 return $model->translations[$originalAttribute][$locale] ?? '';

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\NovaTranslatable\Tests;
 
 use Laravel\Nova\Fields\Field;
+use Laravel\Nova\Fields\FieldCollection;
 use Laravel\Nova\Fields\Text;
 use Spatie\NovaTranslatable\Exceptions\InvalidConfiguration;
 use Spatie\NovaTranslatable\Translatable;
@@ -91,5 +92,26 @@ class TranslatableTest extends TestCase
         $this->expectException(InvalidConfiguration::class);
 
         Translatable::make([]);
+    }
+
+    /** @test */
+    public function it_sets_correct_attribute_on_fields()
+    {
+        $translatable = Translatable::make([
+            new Text('title')
+        ]);
+
+        $this->assertEquals($translatable->data[0]->attribute, 'translations_title_en');
+    }
+
+    /** @test */
+    public function it_works_when_finding_field_by_attribute()
+    {
+        $fields = Translatable::make([new Text('title')])->data;
+        $collections = FieldCollection::make($fields);
+
+        $field = $collections->findFieldByAttribute('translations_title_en');
+
+        $this->assertEquals(optional($field)->attribute, 'translations_title_en');
     }
 }


### PR DESCRIPTION
I was trying to build a translatable `Trix` field with image attachments. But when images are attached and sent to `TrixAttachmentController`, it fails to find the field in question using an attribute. Because the existing implementation sets the attribute of any translatable field to `translations`. I read that the author had a reason to do that [here](https://github.com/laravel/nova-issues/issues/827). That issue is closed and seems to be fixed with subsequent releases of Laravel Nova. So in this PR, I have replaced the translatable field's attribute with `'translations_'.$originalAttribute.'_'.$locale` which was previously used only in `fillUsing` method.

You can use this [sample project](https://github.com/xdiaoa/nova-translatable-trix-issue) to check this issue.

@freekmurze Thanks for the wonderful work **Spatie** is doing for the Laravel Community.