### PR TITLE
[Feature] Different rules per locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,33 @@ Translatable::make([
 
 Using the code about above the name for the `title` field will be "My title ['en']".
 
+### Customizing the rules of a translatable
+
+You may use the regular Nova functionality to define rules on the fields inside your Translatable fields collection. However, this will apply those rules to all locales. If you wish to define different rules per locale you can do so on the Translatable collection.
+
+```php
+Translatable::make([
+    Text::make('My title', 'title'),
+    Trix::make('text'),
+])->rules([
+        'title' => ['en' => 'required', 'nl' => 'nullable'],
+        'text' => ['en' => 'required|min:10', 'nl' => 'nullable|min:10'],
+    ]
+),
+```
+
+You may also use the more fluent `rulesFor()` method, which allows you to define rules per field per locale.
+
+```php
+Translatable::make([
+    Text::make('My title', 'title'),
+    Trix::make('text'),
+])->rulesFor('title', 'en', 'required')
+->rulesFor('title', 'nl', 'nullable'),
+```
+
+There are also methods for update and creation rules called `creationRules()`, `updateRules()`, `creationRulesFor()` and `updateRulesFor()`. They function in the same way as the `rules()` and `rulesFor()` methods.
+
 ## On customizing the UI
 
 You might wonder why we didn't render the translatable fields in tabs, panels or with magical unicorns displayed next to them. The truth is that everybody wants translations to be displayed a bit different. That's why we opted to keep them very simple for now.

--- a/composer.json
+++ b/composer.json
@@ -44,5 +44,8 @@
         "sort-packages": true
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "scripts": {
+        "test": "vendor/bin/phpunit"
+    }
 }

--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -27,6 +27,9 @@ class Translatable extends MergeValue
     /** @var \Closure */
     protected $displayLocalizedNameUsingCallback;
 
+    /** @var array */
+    protected $rules = [];
+
     /**
      * The field's assigned panel.
      *
@@ -64,6 +67,24 @@ class Translatable extends MergeValue
     public function locales(array $locales)
     {
         $this->locales = $locales;
+
+        $this->createTranslatableFields();
+
+        return $this;
+    }
+
+    public function rules(array $rules)
+    {
+        $this->rules = $rules;
+
+        $this->createTranslatableFields();
+
+        return $this;
+    }
+
+    public function rulesFor(string $field, string $locale, $rules)
+    {
+        $this->rules[$field][$locale] = $rules;
 
         $this->createTranslatableFields();
 
@@ -127,6 +148,10 @@ class Translatable extends MergeValue
         $translatedField->fillUsing(function ($request, $model, $attribute, $requestAttribute) use ($locale, $originalAttribute) {
             $model->setTranslation($originalAttribute, $locale, $request->get($requestAttribute));
         });
+
+        if (isset($this->rules[$originalAttribute][$locale])) {
+            $translatedField->rules($this->rules[$originalAttribute][$locale]);
+        }
 
         return $translatedField;
     }

--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -30,6 +30,12 @@ class Translatable extends MergeValue
     /** @var array */
     protected $rules = [];
 
+    /** @var array */
+    protected $creationRules = [];
+
+    /** @var array */
+    protected $updateRules = [];
+
     /**
      * The field's assigned panel.
      *
@@ -82,9 +88,45 @@ class Translatable extends MergeValue
         return $this;
     }
 
+    public function creationRules(array $rules)
+    {
+        $this->creationRules = $rules;
+
+        $this->createTranslatableFields();
+
+        return $this;
+    }
+
+    public function updateRules(array $rules)
+    {
+        $this->updateRules = $rules;
+
+        $this->createTranslatableFields();
+
+        return $this;
+    }
+
     public function rulesFor(string $field, string $locale, $rules)
     {
         $this->rules[$field][$locale] = $rules;
+
+        $this->createTranslatableFields();
+
+        return $this;
+    }
+
+    public function creationRulesFor(string $field, string $locale, $rules)
+    {
+        $this->creationRules[$field][$locale] = $rules;
+
+        $this->createTranslatableFields();
+
+        return $this;
+    }
+
+    public function updateRulesFor(string $field, string $locale, $rules)
+    {
+        $this->updateRules[$field][$locale] = $rules;
 
         $this->createTranslatableFields();
 
@@ -151,6 +193,12 @@ class Translatable extends MergeValue
 
         if (isset($this->rules[$originalAttribute][$locale])) {
             $translatedField->rules($this->rules[$originalAttribute][$locale]);
+        }
+        if (isset($this->creationRules[$originalAttribute][$locale])) {
+            $translatedField->creationRules($this->creationRules[$originalAttribute][$locale]);
+        }
+        if (isset($this->updateRules[$originalAttribute][$locale])) {
+            $translatedField->updateRules($this->updateRules[$originalAttribute][$locale]);
         }
 
         return $translatedField;

--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -192,13 +192,25 @@ class Translatable extends MergeValue
         });
 
         if (isset($this->rules[$originalAttribute][$locale])) {
-            $translatedField->rules($this->rules[$originalAttribute][$locale]);
+            $translatedField->rules(
+                is_string($this->rules[$originalAttribute][$locale])
+                    ? explode('|', $this->rules[$originalAttribute][$locale])
+                    : $this->rules[$originalAttribute][$locale]
+            );
         }
         if (isset($this->creationRules[$originalAttribute][$locale])) {
-            $translatedField->creationRules($this->creationRules[$originalAttribute][$locale]);
+            $translatedField->creationRules(
+                is_string($this->creationRules[$originalAttribute][$locale])
+                    ? explode('|', $this->creationRules[$originalAttribute][$locale])
+                    : $this->creationRules[$originalAttribute][$locale]
+            );
         }
         if (isset($this->updateRules[$originalAttribute][$locale])) {
-            $translatedField->updateRules($this->updateRules[$originalAttribute][$locale]);
+            $translatedField->updateRules(
+                is_string($this->updateRules[$originalAttribute][$locale])
+                    ? explode('|', $this->updateRules[$originalAttribute][$locale])
+                    : $this->updateRules[$originalAttribute][$locale]
+            );
         }
 
         return $translatedField;

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -92,4 +92,21 @@ class TranslatableTest extends TestCase
 
         Translatable::make([]);
     }
+
+    /** @test */
+    public function it_accepts_different_rules_for_different_locales()
+    {
+        $translatable = Translatable::make([
+            new Text('title'),
+        ])->rules(['title' => ['en' => 'required', 'fr' => 'min:3']]);
+
+        $this->assertCount(3, $translatable->data);
+
+        $this->assertEquals($translatable->data[0]->rules, ['required']);
+        $this->assertEquals($translatable->data[1]->rules, ['min:3']);
+
+        $translatable->rulesFor('title', 'en', 'max:3');
+
+        $this->assertEquals($translatable->data[0]->rules, ['max:3']);
+    }
 }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -100,13 +100,41 @@ class TranslatableTest extends TestCase
             new Text('title'),
         ])->rules(['title' => ['en' => 'required', 'fr' => 'min:3']]);
 
-        $this->assertCount(3, $translatable->data);
-
         $this->assertEquals($translatable->data[0]->rules, ['required']);
         $this->assertEquals($translatable->data[1]->rules, ['min:3']);
 
         $translatable->rulesFor('title', 'en', 'max:3');
 
         $this->assertEquals($translatable->data[0]->rules, ['max:3']);
+    }
+
+    /** @test */
+    public function it_accepts_different_creation_rules_for_different_locales()
+    {
+        $translatable = Translatable::make([
+            new Text('title'),
+        ])->creationRules(['title' => ['en' => 'required', 'fr' => 'min:3']]);
+
+        $this->assertEquals($translatable->data[0]->creationRules, ['required']);
+        $this->assertEquals($translatable->data[1]->creationRules, ['min:3']);
+
+        $translatable->creationRulesFor('title', 'en', 'max:3');
+
+        $this->assertEquals($translatable->data[0]->creationRules, ['max:3']);
+    }
+
+    /** @test */
+    public function it_accepts_different_update_rules_for_different_locales()
+    {
+        $translatable = Translatable::make([
+            new Text('title'),
+        ])->updateRules(['title' => ['en' => 'required', 'fr' => 'min:3']]);
+
+        $this->assertEquals($translatable->data[0]->updateRules, ['required']);
+        $this->assertEquals($translatable->data[1]->updateRules, ['min:3']);
+
+        $translatable->updateRulesFor('title', 'en', 'max:3');
+
+        $this->assertEquals($translatable->data[0]->updateRules, ['max:3']);
     }
 }


### PR DESCRIPTION
Hello,

first time pull-requester here in the environment of Spatie. I'm hoping to get a feature in that I personally could use in one of my projects.

So, we have various translatable models, and of course our editors work in a Nova panel to edit and create them. The particular case we have is about news articles. The main language of our website is English, but we also publish in German and French. 

In our workflow, an author will get to work writing and Article in English, and then publish it. After that is done he or she will begin translating the article to the other languages.

Currently we do not use any rules on our fields for news articles, because if we would set the title to required, it would require a title in English, German and French. But we only want the English title to be required, and the translations optional.

This pull request aims to solve this problem.

It contains six new public methods that can be called on the Translatable fields:

`rules(array $rules)`
The rules method will take a nested array of field names, which then in turn contain a key-value pair of a locale and its rules. For example:
```php
$translatable->rules(['title' => ['en' => 'required']])
```

`rulesFor(string $field, string $locale, $rules)`
A more dynamic method to declare rules per field. A syntax I personally find a little more elegant and readable. It achieves the same behaviour like so:
```php
$translatable->rulesFor('title', 'en', 'required');
```

In addition to those two, there are also methods for creation rules and update rules.

Of course, all methods work with all three types of Laravel rules declaration (string, array and Rule classes).

That's it from me. Any feedback is greatly appreciated.

Resolves: https://github.com/spatie/nova-translatable/issues/64