### PR TITLE
Fix undefined array index for route actions without controller

### DIFF
--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -230,7 +230,7 @@ class Translatable extends MergeValue
             return false;
         }
 
-        $currentController = Str::before(request()->route()->getAction()['controller'], '@');
+        $currentController = Str::before(request()->route()->getAction()['controller'] ?? '', '@');
 
         return $currentController === ResourceIndexController::class;
     }


### PR DESCRIPTION
As discussed in #79 this will solve the issue with an error being thrown when there is no array key 'controller' on the route()->getAction() in src/Translatable.php:233.