### PR TITLE
Make Slug field compatible

### DIFF
--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Resources\MergeValue;
 use Illuminate\Support\Str;
 use Laravel\Nova\Fields\Field;
+use Laravel\Nova\Fields\Slug;
 use Laravel\Nova\Http\Controllers\ResourceIndexController;
 use Spatie\NovaTranslatable\Exceptions\InvalidConfiguration;
 
@@ -194,6 +195,10 @@ class Translatable extends MergeValue
 
                 return $model->translations[$originalAttribute][$locale] ?? '';
             });
+
+        if ($translatedField instanceof Slug && !empty($translatedField->from)) {
+            $translatedField->from('translations_'.$translatedField->from.'_'.$locale);
+        }
 
         $translatedField->fillUsing(function ($request, $model, $attribute, $requestAttribute) use ($locale, $originalAttribute) {
             $model->setTranslation($originalAttribute, $locale, $request->get($requestAttribute));


### PR DESCRIPTION
Hi,

This PR refers to this previous issue : https://github.com/spatie/nova-translatable/issues/75

If a slug field is used with a non empty `from` property, package will overrides this property with "translated" conversion.

![nova_slug_translatable](https://user-images.githubusercontent.com/11064382/178239776-81425382-c4e6-4c3d-b2d6-bf6567e45076.gif)

