### PR TITLE
Backport per-locale field rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,33 @@ Translatable::make([
 
 Using the code about above the name for the `title` field will be "My title ['en']".
 
+### Customizing the rules of a translatable
+
+You may use the regular Nova functionality to define rules on the fields inside your Translatable fields collection. However, this will apply those rules to all locales. If you wish to define different rules per locale you can do so on the Translatable collection.
+
+```php
+Translatable::make([
+    Text::make('My title', 'title'),
+    Trix::make('text'),
+])->rules([
+        'title' => ['en' => 'required', 'nl' => 'nullable'],
+        'text' => ['en' => 'required|min:10', 'nl' => 'nullable|min:10'],
+    ]
+),
+```
+
+You may also use the more fluent `rulesFor()` method, which allows you to define rules per field per locale.
+
+```php
+Translatable::make([
+    Text::make('My title', 'title'),
+    Trix::make('text'),
+])->rulesFor('title', 'en', 'required')
+->rulesFor('title', 'nl', 'nullable'),
+```
+
+There are also methods for update and creation rules called `creationRules()`, `updateRules()`, `creationRulesFor()` and `updateRulesFor()`. They function in the same way as the `rules()` and `rulesFor()` methods.
+
 ## On customizing the UI
 
 You might wonder why we didn't render the translatable fields in tabs, panels or with magical unicorns displayed next to them. The truth is that everybody wants translations to be displayed a bit different. That's why we opted to keep them very simple for now.

--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -34,6 +34,15 @@ class Translatable extends MergeValue
     /** @var \Closure */
     protected $displayLocalizedNameUsingCallback;
 
+    /** @var array */
+    protected $rules = [];
+
+    /** @var array */
+    protected $creationRules = [];
+
+    /** @var array */
+    protected $updateRules = [];
+
     /**
      * The field's assigned panel.
      *
@@ -73,6 +82,60 @@ class Translatable extends MergeValue
     public function locales(array $locales)
     {
         $this->locales = $locales;
+
+        $this->createTranslatableFields();
+
+        return $this;
+    }
+
+    public function rules(array $rules)
+    {
+        $this->rules = $rules;
+
+        $this->createTranslatableFields();
+
+        return $this;
+    }
+
+    public function creationRules(array $rules)
+    {
+        $this->creationRules = $rules;
+
+        $this->createTranslatableFields();
+
+        return $this;
+    }
+
+    public function updateRules(array $rules)
+    {
+        $this->updateRules = $rules;
+
+        $this->createTranslatableFields();
+
+        return $this;
+    }
+
+    public function rulesFor(string $field, string $locale, $rules)
+    {
+        $this->rules[$field][$locale] = $rules;
+
+        $this->createTranslatableFields();
+
+        return $this;
+    }
+
+    public function creationRulesFor(string $field, string $locale, $rules)
+    {
+        $this->creationRules[$field][$locale] = $rules;
+
+        $this->createTranslatableFields();
+
+        return $this;
+    }
+
+    public function updateRulesFor(string $field, string $locale, $rules)
+    {
+        $this->updateRules[$field][$locale] = $rules;
 
         $this->createTranslatableFields();
 
@@ -140,6 +203,28 @@ class Translatable extends MergeValue
         $translatedField->fillUsing(function ($request, $model, $attribute, $requestAttribute) use ($locale, $originalAttribute) {
             $model->setTranslation($originalAttribute, $locale, $request->get($requestAttribute));
         });
+
+        if (isset($this->rules[$originalAttribute][$locale])) {
+            $translatedField->rules(
+                is_string($this->rules[$originalAttribute][$locale])
+                    ? explode('|', $this->rules[$originalAttribute][$locale])
+                    : $this->rules[$originalAttribute][$locale]
+            );
+        }
+        if (isset($this->creationRules[$originalAttribute][$locale])) {
+            $translatedField->creationRules(
+                is_string($this->creationRules[$originalAttribute][$locale])
+                    ? explode('|', $this->creationRules[$originalAttribute][$locale])
+                    : $this->creationRules[$originalAttribute][$locale]
+            );
+        }
+        if (isset($this->updateRules[$originalAttribute][$locale])) {
+            $translatedField->updateRules(
+                is_string($this->updateRules[$originalAttribute][$locale])
+                    ? explode('|', $this->updateRules[$originalAttribute][$locale])
+                    : $this->updateRules[$originalAttribute][$locale]
+            );
+        }
 
         return $translatedField;
     }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -130,4 +130,49 @@ class TranslatableTest extends TestCase
         $this->assertEquals($disk, $field->getStorageDisk());
         $this->assertEquals($path, $field->getStorageDir());
     }
+
+    /** @test */
+    public function it_accepts_different_rules_for_different_locales()
+    {
+        $translatable = Translatable::make([
+            new Text('title'),
+        ])->rules(['title' => ['en' => 'required', 'fr' => 'min:3']]);
+
+        $this->assertEquals($translatable->data[0]->rules, ['required']);
+        $this->assertEquals($translatable->data[1]->rules, ['min:3']);
+
+        $translatable->rulesFor('title', 'en', 'max:3');
+
+        $this->assertEquals($translatable->data[0]->rules, ['max:3']);
+    }
+
+    /** @test */
+    public function it_accepts_different_creation_rules_for_different_locales()
+    {
+        $translatable = Translatable::make([
+            new Text('title'),
+        ])->creationRules(['title' => ['en' => 'required', 'fr' => 'min:3']]);
+
+        $this->assertEquals($translatable->data[0]->creationRules, ['required']);
+        $this->assertEquals($translatable->data[1]->creationRules, ['min:3']);
+
+        $translatable->creationRulesFor('title', 'en', 'max:3');
+
+        $this->assertEquals($translatable->data[0]->creationRules, ['max:3']);
+    }
+
+    /** @test */
+    public function it_accepts_different_update_rules_for_different_locales()
+    {
+        $translatable = Translatable::make([
+            new Text('title'),
+        ])->updateRules(['title' => ['en' => 'required', 'fr' => 'min:3']]);
+
+        $this->assertEquals($translatable->data[0]->updateRules, ['required']);
+        $this->assertEquals($translatable->data[1]->updateRules, ['min:3']);
+
+        $translatable->updateRulesFor('title', 'en', 'max:3');
+
+        $this->assertEquals($translatable->data[0]->updateRules, ['max:3']);
+    }
 }


### PR DESCRIPTION
As the per-locale field rules feature was only released to the 4.x version of this package, it's good to also backport this to 3.x if possible.

Code from https://github.com/spatie/nova-translatable/pull/70/files