### PR TITLE
Add missing "translatedFieldsByLocale" property

### DIFF
--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -36,6 +36,9 @@ class Translatable extends MergeValue
     /** @var array */
     protected $updateRules = [];
 
+    /** @var array */
+    protected $translatedFieldsByLocale = [];
+
     /**
      * The field's assigned panel.
      *


### PR DESCRIPTION
Fixes https://github.com/spatie/nova-translatable/issues/92 / deprecation warning in PHP 8.3 